### PR TITLE
add toc and clean up repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,24 @@
 
 This repository holds the current design specification for [Lock Keeper](https://github.com/boltlabs-inc/key-mgmt), a human-centric digital asset management system.
 
-## Goals
+## Navigation
+[**Specification Overview**](#overview)<br>
+[**Current Development Phase**](current-development-phase.md) <br>
+[**Where to Find Code**](repository-list.md)<br>
+[**Glossary**](glossary.md)
+
+## Overview
+### Goals
 We are designing and building Lock Keeper iteratively, so this specification is meant to be a single point of truth for our current development phase.
 
 At a high level, we want to capture information that helps developers and the public understand the properties of our digital asset management system, as well as a formal specification of the underlying cryptographic protocols used. 
 
-## Expected Audience
+### Expected Audience
 We want this repository to be a helpful reference for the following groups:
 - Developers who are integrating our code into a larger system.
 - Cryptographers and security engineers who are auditing our system design and/or code.
 
-## In Scope
+### In Scope
 Here is a working list of what should be included in this repository:
 - An overview of what the product is expected to accomplish in our current development phase. Because we are designing and implementing the product iteratively, this should be updated regularly.
 - Integration guidance for developers, including any requirements or assumptions for the calling application(s) and how the calling application(s) fits in the overall system architecture, i.e., which components are external-facing. This will be helpful for iterating on our external-facing APIs and overall system functionality.
@@ -20,7 +27,7 @@ Here is a working list of what should be included in this repository:
 - A specification of the system's application-layer session handling and assumptions on the underlying transport layer. This will be helpful for design iteration, analysis, audits, and obtaining feedback from the community.
 - A specification of the system's cryptographic protocol flows. This should include a description of underlying cryptographic assumptions and desired properties. This will be helpful for design iteration, analysis, audits, and obtaining feedback from the community.
 
-## Out of Scope
+### Out of Scope
 We do not attempt to capture granular, non-cryptographic implementation and software architecture decisions. This type of development decision should be documented clearly in [Lock Keeper](https://github.com/boltlabs-inc/key-mgmt).
 
 

--- a/client-api.md
+++ b/client-api.md
@@ -1,1 +1,0 @@
-This file describes the public API that the key-mgmt project will make available to a user application.

--- a/current-development-phase.md
+++ b/current-development-phase.md
@@ -1,4 +1,4 @@
-# Arbitrary Secrets Proof of Concept Overview
+# Arbitrary Secrets Proof of Concept 
 
 In this phase, we want to build a general-purpose, human-centric system that stores and retrieves secrets on a single server. This proof of concept (PoC) will include basic cryptography to realize an end-to-end encrypted storage of arbitrary secrets. This constitutes a fundamental building block of our larger imagined digital asset management system. 
 

--- a/entities.md
+++ b/entities.md
@@ -1,5 +1,0 @@
-Definitions of entities involved in the key-mgmt project.
-
-* Asset owner: the human that owns digital assets and the corresponding keys.
-* Key server: a server that participates in secure generation, storage, and use of a key (or key share).
-* User application: a middleman application that provides an interface between the asset owner and the key-mgmt client API.

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,10 @@
+# Glossary
+**Asset owner**: A human that owns digital assets and wishes to store related secrets using Lock Keeper. 
+
+**Demo repository**: A repository that demonstrates usage of the client and server libraries. <br>
+[TODO](https://github.com/boltlabs-inc/key-mgmt/issues/93): Add location after set-up.
+
+**Client**: Software that runs on an asset owner's device and initiates workflows involving secrets.
+
+**Key server**: A server that enables both secure storage and use of secrets.
+

--- a/policy-engine.md
+++ b/policy-engine.md
@@ -1,7 +1,0 @@
-This file describes the expected behavior of the policy engine via its interactions with the key servers. It also defines the supplementary information that the key servers must have in order to determine how to interact with the policy engine.
-
-# API
-Expected behavior of the policy engine. Note that this does not assume a specific policy engine architecture - although it is written as if the policy engine is a single server, we acknowledge that it may be instantiated by, for example, calls to several policy servers.
-
-
-# Supplemental information

--- a/repository-list.md
+++ b/repository-list.md
@@ -12,3 +12,4 @@ A [repository]() that demonstrates usage of the `local-client` and `key-server` 
 This demo contains two parts:
 1. A sample human-facing calling application that integrates the `local-client` library. That is, this application provides an interface between the asset owner and the key-mgmt `local-client` API.
 1. A demonstration setup for the key server.
+1. A Dockerfile for testing the sample calling app with the `local-client` library and key server on any machine.

--- a/repository-list.md
+++ b/repository-list.md
@@ -1,0 +1,14 @@
+# Where to Find Code
+
+## Lock Keeper Libraries
+Our libraries exist in the [`key-mgmt`](https://github.com/boltlabs-inc/key-mgmt) repository.
+- [`local-client`](https://github.com/boltlabs-inc/key-mgmt/tree/develop/dams-local-client): This is a Rust library that can be integrated into a human-facing calling application that runs on an asset owner's device. All operations on the key server are initiated by this client. See [here](systems-architecture.md#local_client) for more details.
+- [`key-server`](https://github.com/boltlabs-inc/key-mgmt/tree/develop/dams-key-server): This library can be integrated into a host server in order to provide end-to-end encrypted storage of secrets. See [here](systems-architecture.md#key_server) for more details.
+
+## Demo Repository
+A [repository]() that demonstrates usage of the `local-client` and `key-server` libraries.<br>
+[TODO](https://github.com/boltlabs-inc/key-mgmt/issues/93) Add link to location above.
+
+This demo contains two parts:
+1. A sample human-facing calling application that integrates the `local-client` library. That is, this application provides an interface between the asset owner and the key-mgmt `local-client` API.
+1. A demonstration setup for the key server.

--- a/systems-architecture.md
+++ b/systems-architecture.md
@@ -2,15 +2,20 @@
 
 ## Components
 
-### Local client 
-This library component is integrated into Service Provider software that runs on the asset owner's device. The Service Provider may choose to directly integrate this library into a mobile application or as hardened WASM into a browser-based service. This component interfaces with the key server component. 
+### Client 
+This software MUST run on the asset owner's device in order for the desired security property to be achieved. 
+The client functionality is split between a library and a demo repository that shows how to integrate the library into a human-facing application; see [here](repository-list.md) for more details. This component interfaces with the key server component and is responsible for realizing [the asset owner workflows](current-development-phase.md#workflows) in the current development phase.
 
-This component is responsible for realizing [the asset owner workflows](current-development-phase.md#workflows) in the current development phase.
+In practice, the Service Provider may choose to directly integrate the library component into a mobile application or as hardened WASM into a browser-based service. 
+
+
 
 ### Key server
-The library component is integrated into a host server run by the Service Provider or an external cloud provider. This component interfaces with the local client.
+The library component is integrated into a host server and interfaces with the client component.
 
 This component is responsible for encrypted storage of secrets on behalf of the asset owner. That is, the key server performs operations on secrets as requested by the asset owner. See [the asset owner workflows](current-development-phase.md#workflows) for more information on the allowed operations. 
+
+In practice, the Service Provider may choose to either run the host server themselves or use one or more external cloud providers. The best security properties will be achieved by distributing trust across multiple cloud providers.
 
 ## Networking
 ### Session requirements


### PR DESCRIPTION
This PR does some general cleanup to bring the repository into a state of consistency with the current development phase: Arbitrary Secrets PoC. It also aims to improve general readability and navigation within the repo.

Included:
- TOC added. (Closes #25).
- Adds a file that describes where to find our repositories (and in the case of a demo, links to a new ticket).
- Changes a document that defined entities into a general-purpose glossary.