### PR TITLE
Add retrieve details 

### DIFF
--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -25,12 +25,11 @@ An asset owner that has not previously interacted with the key server MUST regis
     1. [Stores](#server-side-storage) the received ciphertext in a record associated with `user_id`.
 1. The client and server close the session upon completion of the request.
 
-We will assume the following:
-   
-   - `retrieve_storage_key`, A function will be implemented that allows the client to retrieve and locally decrypt the ciphertext to recover `storage_key`.
-  
-## Generate and Store
-This client-side functionality generates a secret locally and stores the result both locally and remotely:
+## Generate and Store a Secret
+- [TODO](https://github.com/boltlabs-inc/key-mgmt-spec/issues/43): Determine failure and retry behavior for this protocol: what is the client behavior after receipt of ACK?
+
+This client-initiated functionality generates a secret locally and stores the result both locally and remotely:
+>>>>>>> f5e927a (Add retrieve details #12)
 
 Input:
 - `user_id`, a 128-bit globally unique identifier (GUID) representing the identity of the asset owner.
@@ -40,11 +39,11 @@ Output:
 
 Protocol:
 1. The client:
-   1. Checks if there is an existing open session with the key server and the input `user_id` and [opens a Request Session](systems-architecture.md#request-session) if not. 
-   1. Calls `retrieve_storage_key`, the output of which is `storage_key`.
+   1. [Opens a request session](systems-architecture.md#request-session) for the given user id `user_id`. 
+   1. Calls [`retrieve_storage_key`](#retrieve-storagekey-functionality), the output of which is `storage_key`.
    1. Sends a request message to the key server over the session's secure channel. This message MUST indicate the desire to store a secret remotely and contain `user_id`.
 1. The key server:
-   1. Runs a validity check on the received `user_id` (i.e., `user_id` must be of the expected format and length, and should match the current authenticated session).
+   1. Runs a validity check on the received request and `user_id`(i.e., there must be a valid open request session, the request must conform to the expected format, and `user_id` must be of the expected format and length, and should match that of the open request session). If this check fails, the server MUST reject the request.
    1. Generates `key_id`, a globally unique identifier as follows:
         1. Generates `randomness` as 32 bytes of randomness output from `rng`.
         1. Computes `key_id` as `Hash(domain_sep, 16, user_id, 32, randomness)`, truncated to 128-bits if necessary, where `domain_sep` is a static string acting as a domain separator, prepended with its length in bytes.
@@ -60,7 +59,42 @@ Protocol:
     1. Sends an ACK to the client.
 1. The client closes the session.
 
-[TODO](https://github.com/boltlabs-inc/key-mgmt-spec/issues/43): Determine failure and retry behavior for this protocol: what is the client behavior after receipt of ACK?
+
+## Retrieve a Secret
+This client-initiated functionality retrieves a secret from the system.
+
+Input:
+- `user_id`, a 128-bit globally unique identifier (GUID) representing the identity of the asset owner.
+- `key_id`, a 128-bit unique identifier representing a key.
+
+Output:
+- `arbitrary_key`, the arbitrary secret that is backed up remotely.
+
+Protocol:
+1. The client:
+   1. [Opens a request session](systems-architecture.md#request-session) for the given user id `user_id`. 
+   1. Calls [`retrieve_storage_key`](#retrieve-storagekey-functionality), the output of which is `storage_key`. The implementation SHOULD keep this key in memory only and not write to disk.
+   1. [Retrieves](#client-side-storage) the ciphertext `ciphertext` associated to `key_id` from local storage. 
+        1. If successful, computes `arbitrary_key = Dec(storage_key, ciphertext, user_id||key_id)`, outputs `arbitrary_key`, and closes the request session. 
+        1. Otherwise, continues.
+   1. Sends a request message to the key server over the open session's secure channel. This message MUST indicate the desire to retrieve the backed up secret and contain `user_id` and `key_id`.
+1. The key server:
+    1. Runs a validity check on the received request, `user_id`, and `key_id`. That is,
+        1. There must be a valid open request session, 
+        1. The request must conform to the expected format and content, 
+        1. The `user_id` must be of the expected format and length, and should match that of the open request session,
+        1. The `key_id` must be associated with the given `user_id` in the key server's database.
+       If this check fails, the server MUST reject the request.
+    1. [Retrieves](#server-side-storage) the associated ciphertext and associated data for the given pair `(user_id, key_id)` from its database and sends this ciphertext, together with the associated data, to the client.
+1. The client:
+    1. Computes `arbitrary_key = Dec(storage_key, ciphertext, user_id||"storage key")`, where `ciphertext` is the received ciphertext from the key server.
+    1. Deletes `storage_key` from memory.
+    1. Closes the open request session.
+    1. [Stores](#client-side-storage) `ciphertext` in its local storage.
+    1. Outputs `arbitrary_key`.
+
+Usage guidance: The calling application SHOULD enable the asset owner to copy-paste the password to the system clipboard for one-time use and then makes a best effort to delete this secret from memory.
+  
 
 ## Cryptographic and Supporting Operations
 ### External dependencies
@@ -96,6 +130,30 @@ Protocol:
 
 Usage guidance:
 Code that consumes an `arbitrary_key` SHOULD include validation checks specific to the context before use, i.e., an `arbitrary_key` SHOULD be used only in the context for which it was initially generated.
+
+### `Retrieve_storage_key` functionality
+This functionality allows the client to request and receive the key `storage_key` from the key server, where `storage_key` is a symmetric key for the implementation's selected AEAD used for remote storage.
+
+Inputs:
+- An open request session.
+- `user_id`, a universally unique identifer that represents the user.
+- `export_key`, a symmetric key from the open request session.
+
+Outputs:
+- `storage_key`, a symmetric key for an AEAD scheme.
+
+Protocol:
+1. The client:
+    1. If the client does not have an [open request session](systems-architecture.md#opening-and-using-a-request-session) with the key server, calling this function should output an error.
+    1. Sends a request message to the key server over the open session's secure channel. This message MUST indicate the desire to retrieve the storage key and contain `user_id`.
+1. The key server:
+    1. Runs a validity check on the received request and `user_id` (i.e., there must be a valid open request session, the request must conform to the expected format and content, and `user_id` must be of the expected format and length, and should match that of the open request session). If this check fails, the server MUST reject the request.
+    1. [Retrieves](#server-side-storage) the associated storage key ciphertext for the given user from its database and sends this ciphertext to the client.
+1. The client:
+    1. Computes `Dec(export_key, ciphertext, user_id||"storage key")`, where `ciphertext` is the received ciphertext from the key server, and outputs `storage_key`.
+       - TODO: update this to be consistent with the derived key used instead of `export_key` here.
+
+Usage guidance: Code that calls the `retrieve_storage_key` functionality SHOULD NOT write the output `storage_key` to disk and should make a best effort to drop this key from temporary memory after use of this key is completed.
 
 ### Client-side storage
 

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -131,7 +131,7 @@ Protocol:
 Usage guidance:
 Code that consumes an `arbitrary_key` SHOULD include validation checks specific to the context before use, i.e., an `arbitrary_key` SHOULD be used only in the context for which it was initially generated.
 
-### `Retrieve_storage_key` functionality
+### `retrieve_storage_key` functionality
 This functionality allows the client to request and receive the key `storage_key` from the key server, where `storage_key` is a symmetric key for the implementation's selected AEAD used for remote storage.
 
 Inputs:

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -15,7 +15,7 @@ An asset owner that has not previously interacted with the key server MUST regis
         - The `storage key` MUST NOT be saved, stored, or used in any context outside this protocol. It must not be passed to the calling application.
     1. Computes a ciphertext `encrypted_storage_key = Enc(master_key, storage_key, user_id||"storage key"|context)`.
     1. <a name="complete-registration"></a> Sends a request message to the key server over the registration session's secure channel. This message MUST indicate the desire to _complete registration_ and contain `user_id` and the ciphertext `encrypted_storage_key`.
-    1. Deletes `storage_key` from memory.
+    1. Deletes `storage_key` and `master_key` from memory.
         - [TODO #51](https://github.com/boltlabs-inc/key-mgmt-spec/issues/51): Update this when additional requests are allowed.
 1. The server:
     1. Checks that `user_id` matches that of the authenticated user in the open registration session. If this check fails, the server MUST abort.
@@ -149,7 +149,9 @@ Protocol:
     1. Derives `master_key`, a symmetric key of length `len` bytes for [`Enc`](#external-dependencies), from `export_key`, as follows:
         1. Length `len` should be the default for `Enc`.
         1. Set `master_key = HKDF(export_key, "OPAQUE-derived Lock Keeper master key")`.
-    1. Computes `storage_key = Dec(master_key, ciphertext, user_id||"storage key")`, where `ciphertext` is the received ciphertext from the key server, and outputs `storage_key`.
+    1. Computes `storage_key = Dec(master_key, ciphertext, user_id||"storage key")`, where `ciphertext` is the received ciphertext from the key server.
+    1. Deletes `master_key` from memory.
+    1. Outputs `storage_key`.
 
 Usage guidance: Code that calls the `retrieve_storage_key` functionality SHOULD NOT write the output `storage_key` to disk and should make a best effort to drop this key from temporary memory after use of this key is completed.
 

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -26,10 +26,9 @@ An asset owner that has not previously interacted with the key server MUST regis
 1. The client and server close the session upon completion of the request.
 
 ## Generate and Store a Secret
-- [TODO](https://github.com/boltlabs-inc/key-mgmt-spec/issues/43): Determine failure and retry behavior for this protocol: what is the client behavior after receipt of ACK?
+- [TODO #43](https://github.com/boltlabs-inc/key-mgmt-spec/issues/43): Determine failure and retry behavior for this protocol: what is the client behavior after receipt of ACK?
 
-This client-initiated functionality generates a secret locally and stores the result both locally and remotely:
->>>>>>> f5e927a (Add retrieve details #12)
+This client-initiated functionality generates a secret locally and stores the result both locally and remotely.
 
 Input:
 - `user_id`, a 128-bit globally unique identifier (GUID) representing the identity of the asset owner.
@@ -108,7 +107,6 @@ See [the current development phase](current-development-phase.md#cryptographic-p
 - [A HMAC-based key derivation function](https://datatracker.ietf.org/doc/html/rfc5869) that is parameterized by `Hash` and consists of:
     - A key derivation function `HKDF` that takes a tuple `(salt, input_key, context, len)`, where `salt` is an optional, non-secret random value, `input_key` is the input key material, `context` is an optional context and application-specific information, and `len` is the length of the output keying material in bytes.
 
-
 Inter-dependency constraints include:
 - The length of the a key for `Enc` must be no more than 255 times the length of the output of `Hash`.
 
@@ -161,10 +159,10 @@ Usage guidance: Code that calls the `retrieve_storage_key` functionality SHOULD 
 ### Client-side storage
 
 For now, simple clear-text storage is acceptable.
-- [TODO](https://github.com/boltlabs-inc/key-mgmt-spec/issues/39) Include appropriate requirements for client-side secure storage and generate relevant issues in key-mgmt.
+- [TODO #39](https://github.com/boltlabs-inc/key-mgmt-spec/issues/39) Include appropriate requirements for client-side secure storage and generate relevant issues in key-mgmt.
 
 ### Server-side storage
-- [TODO](https://github.com/boltlabs-inc/key-mgmt-spec/issues/28). Include appropriate requirements for server-side secure storage and generate relevant issues in key-mgmt.
+- [TODO #28](https://github.com/boltlabs-inc/key-mgmt-spec/issues/28). Include appropriate requirements for server-side secure storage and generate relevant issues in key-mgmt.
 
 
 

--- a/current-development-phase.md
+++ b/current-development-phase.md
@@ -10,12 +10,13 @@ In this phase, we want to build a general-purpose, human-centric system that sto
 ## System Architecture
 See the [Systems Architecture page](systems-architecture.md) for details.
 
-There are two basic components: a [local client](systems-architecture.md#local_client) (which runs on an asset owner device and initiates all workflows) and a [key server](systems-architecture.md#key_server) (which provides the storage and retrieval of arbitrary secrets). These components communicate over secure channels at all times. 
+There are two basic components: a [client](systems-architecture.md#client) (which runs on an asset owner device and initiates all workflows) and a [key server](systems-architecture.md#key-server) (which provides the storage and retrieval of arbitrary secrets). These components communicate over secure channels at all times. 
 
 ## Workflows
 We provide sketches of the basic generation, storage, and use of arbitrary secrets below. These flows are initiated by the asset owner. 
 
 ### Setting up secure channels with the key server
+See the [Networking subsection](systems-architecture.md#networking) on the [Systems Architecture page](systems-architecture.md) for details.
 1. The asset owner may _register_ with the key server via an asymmetric password-authenticated key exchange protocol.
     1. Registration MUST occur via a channel that satisfies authentication of the server, confidentiality, and integrity.
 1. The asset owner may _open an authenticated session_ with the key server via an asymmetric password-authenticated key exchange protocol. 
@@ -24,6 +25,8 @@ We provide sketches of the basic generation, storage, and use of arbitrary secre
 1. The asset owner may _close_ a session that the asset owner previously established with the key server.
 
 ### Operations on arbitrary secrets
+See the [Operations on Arbitrary Secrets page](cryptographic_flows.md#) for details.
+
 1. The asset owner can _generate_ a secret locally.
     1. This secret MUST be randomly generated according to the uniform distribution.
     1. This secret should default to 256-bits.
@@ -53,21 +56,24 @@ We provide sketches of the basic generation, storage, and use of arbitrary secre
     1. Non-normative note: Given the above properties, we do not achieve integrity of the audit logs in the presence of a cheating key server. Future work may address this concern.
 
 ## Cryptographic Protocol and Implementation Dependencies
+- [TODO #49](https://github.com/boltlabs-inc/key-mgmt-spec/issues/49): Add dependency information for the above.
 
+We have the following dependencies:
 - We instantiate the asymmetric password-based authenticated key exchange protocol with OPAQUE. We are using [opaque-ke](https://docs.rs/opaque-ke/2.0.0-pre.3/opaque_ke/index.html), which currently implements [version 09 of the IETF RFC](https://datatracker.ietf.org/doc/draft-irtf-cfrg-opaque/09/). This library is under active development, as is the IETF draft. An earlier release of this repository has been audited by NCC Group in June 2021. 
     - This implementation relies on [voprf](https://github.com/novifinancial/voprf), which is tracking [the IETF RFC on OPRFs](https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/).
     - As both of the above RFCs are in flux, we expect ongoing updates.
     - Following the terminology of the RFC, we use the following OPAQUE-3DH configuration: OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, ristretto255, with Argon2 as the KSF, and no shared context information. 
 
 - TLS 1.3. 
-    - [TODO](https://github.com/boltlabs-inc/key-mgmt-spec/issues/22): Select and add config, setup, and implementation dependency information.
-- Cryptographic Hash Function `Hash`. We use SHA3-256 throughout.
+    - [TODO #22](https://github.com/boltlabs-inc/key-mgmt-spec/issues/22): Select and add config, setup, and implementation dependency information.
+- Cryptographic Hash Function `Hash`. We use SHA3-256 throughout in our constructions.
 - CSPRNG, `rng`.
 - A symmetric AEAD scheme that consists of:
     - An encryption function `Enc` that takes a pair `(key, msg, data)`, where `key` is the symmetric key, `msg` is the message to be encrypted, and `data` is OPTIONAL associated data, and outputs a ciphertext.
     - A decryption function `Dec` that takes a pair `(key, ciphertext, data)`, where `key` is the symmetric key,`ciphertext` is the a ciphertext to be decrypted, and `data` is OPTIONAL associated data, and outputs a plaintext.
+ - [A HMAC-based key derivation function](https://datatracker.ietf.org/doc/html/rfc5869) that is parameterized by `Hash` and consists of:
+    - A key derivation function `HKDF` that takes a tuple `(salt, input_key, context, len)`, where `salt` is an optional, non-secret random value, `input_key` is the input key material, `context` is an optional context and application-specific information, and `len` is the length of the output keying material in bytes.
 
-TODO: Add dependency information for the above.
 
 ## Expected Outcomes
 A working command-line demo with cryptography for handling arbitrary secrets. 

--- a/glossary.md
+++ b/glossary.md
@@ -2,7 +2,7 @@
 **Asset owner**: A human that owns digital assets and wishes to store related secrets using Lock Keeper. 
 
 **Demo repository**: A repository that demonstrates usage of the client and server libraries. <br>
-[TODO](https://github.com/boltlabs-inc/key-mgmt/issues/93): Add location after set-up.
+- [TODO #93](https://github.com/boltlabs-inc/key-mgmt/issues/93): Add location after set-up.
 
 **Client**: Software that runs on an asset owner's device and initiates workflows involving secrets.
 

--- a/repository-list.md
+++ b/repository-list.md
@@ -7,7 +7,7 @@ Our libraries exist in the [`key-mgmt`](https://github.com/boltlabs-inc/key-mgmt
 
 ## Demo Repository
 A [repository]() that demonstrates usage of the `local-client` and `key-server` libraries.<br>
-[TODO](https://github.com/boltlabs-inc/key-mgmt/issues/93) Add link to location above.
+- [TODO #93](https://github.com/boltlabs-inc/key-mgmt/issues/93) Add link to location above.
 
 This demo contains two parts:
 1. A sample human-facing calling application that integrates the `local-client` library. That is, this application provides an interface between the asset owner and the key-mgmt `local-client` API.


### PR DESCRIPTION
This PR closes #12.

Things it doesn't address, but came up as questions during drafting:
- User identifiers (see #52). We are using `user_id` for both OPAQUE and our application, but these identifiers should be different. For OPAQUE, the user identifier should be human-memorable account information, whereas the latter is a 128-bit UUID. The likely solution here is that the key server should generate and store this ID during registration (#11), and pass it back to the client during authentication (#10).
- How the user knows its key identifiers. This may relate to #48, or we could implement functionality that retrieves a list of the user's associated data