### PR TITLE
Import export

### DIFF
--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -67,7 +67,10 @@ This client-initiated functionality retrieves a secret from the system and passe
 Input:
 - `user_id`, a 128-bit globally unique identifier (GUID) representing the identity of the asset owner.
 - `key_id`, a 128-bit unique identifier representing a secret.
-- `context`, one of `NULL`, `"local only"`, or `"export"`, which should indicate the asset owner's intended use of the secret.
+- `context`, one of `NULL`, `"local only"`, or `"export"`, which should indicate the asset owner's intended use of the secret:
+    - `NULL`: This option captures internal use of this workflow, i.e., there is no specific asset owner intent specified.
+    - `"local only"`: This option captures immediate uses of the secret that are either local to the calling application or the asset owner's system. 
+    - `"export"`: This option captures other, potentially non-local uses of the secret, i.e., the value is expected to be passed and persist outside of the calling application.
 
 Output:
 - Either a success indicator OR `arbitrary_key`, the arbitrary secret that is backed up remotely.
@@ -105,8 +108,10 @@ Usage guidance: The calling application SHOULD support the intended use of the a
 - If the `context` is set to `"export"`, the calling application SHOULD make a best effort to delete the exported secret from memory.
 
 Non-normative notes: 
-- The context `context` is meant to allow the asset owner the ability to store state at the server as to the intended use of their secret and does NOT provide assurance that the intended use was respected. The calling application SHOULD make a best effort to support the intended use in as conservative a manner as possible.
-- The context `NULL` is for internal testing and system extensibility purposes and does not currently provide a function for the asset owner.
+- The context `context` is meant to allow the asset owner the ability to store state at the server as to the intended use of their secret and does NOT provide assurance that the intended use was respected. The calling application SHOULD make a best effort to support the intended use in as conservative a manner as possible:
+    - The context `"local only"` indicates that secret material is meant to be passed to the calling application, and possibly the asset owner's device system, and used in a limited fashion. The calling application SHOULD allow either no or very restricted use of this value outside of the calling application itself, e.g., passing the value in order to allow one-time use of the system clipboard is acceptable, but passing this material over a network connection is not.
+    - The context `"export"` indicates that the secret material is meant to be passed to and out of the calling application, and persist _outside of the calling application_ itself. This is meant to capture uses like the asset owner creating an external backup of the system or as part of removing the secret from the key server entirely.
+    - The context `NULL` is for internal testing and system extensibility purposes and does not currently provide a function for the asset owner.
 
 ### Import a Secret
 

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -88,10 +88,10 @@ Protocol:
         1. The `user_id` must be of the expected format and length, and should match that of the open request session,
         1. The `key_id` must be associated with the given `user_id` in the key server's database.
         1. The intended use must match one of the expected options.
-    1. [Retrieves](#server-side-storage) the associated ciphertext and associated data for the given pair `(user_id, key_id)` from its database and sends this ciphertext, together with the associated data, to the client.
+    1. [Retrieves](#server-side-storage) the associated ciphertext, `ciphertext` and associated data, `associated_data`, for the given pair `(user_id, key_id)` from its database and sends this ciphertext, together with the associated data, to the client.
         - [TODO #36](https://github.com/boltlabs-inc/key-mgmt-spec/issues/36): The key server should log the intended use of this retrieval request.
 1. The client:
-    1. Computes `arbitrary_key = Dec(storage_key, ciphertext, user_id||"storage key")`, where `ciphertext` is the received ciphertext from the key server.
+    1. Computes `arbitrary_key = Dec(storage_key, ciphertext, user_id||associated_data)`, where `ciphertext` is the received ciphertext from the key server and `associated_data` is the associated data received from the server.
     1. Deletes `storage_key` from memory.
     1. Closes the open request session.
     1. [Stores](#client-side-storage) `ciphertext` in its local storage.

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -48,7 +48,7 @@ Protocol:
 1. The client:
     1. Runs the [generate](#generate-a-secret) protocol on input `(32, rng, user_id||key_id)` to get a secret `arbitrary_key`.
     1. Computes `Enc(storage_key, arbitrary_key, user_id||key_id)` and sends the resulting ciphertext to the key server over the secure channel.
-    1. [Stores](#store-a-secret-locally) the ciphertext and associated data locally.
+    1. [Stores](#store-a-secret-locally) the ciphertext and associated data `user_id||key_id` locally.
 1. The key server:
     1. Runs a validity check on the received ciphertext (i.e., the ciphertext must be of the expected format and length).
     1. [Stores](#server-side-storage) a tuple containing the received ciphertext, `user_id`, and `key_id` in the server database.
@@ -91,7 +91,7 @@ Protocol:
     1. [Retrieves](#server-side-storage) the associated ciphertext, `ciphertext` and associated data, `associated_data`, for the given pair `(user_id, key_id)` from its database and sends this ciphertext, together with the associated data, to the client.
         - [TODO #36](https://github.com/boltlabs-inc/key-mgmt-spec/issues/36): The key server should log the intended use of this retrieval request.
 1. The client:
-    1. Computes `arbitrary_key = Dec(storage_key, ciphertext, user_id||associated_data)`, where `ciphertext` is the received ciphertext from the key server and `associated_data` is the associated data received from the server.
+    1. Computes `arbitrary_key = Dec(storage_key, ciphertext, associated_data)`, where `ciphertext` is the received ciphertext from the key server and `associated_data` is the associated data received from the server.
     1. Deletes `storage_key` from memory.
     1. Closes the open request session.
     1. [Stores](#client-side-storage) `ciphertext` in its local storage.
@@ -132,10 +132,10 @@ Protocol:
    1. Sends `key_id` to the client over the secure channel.
 1. The client:
     1. Computes `Enc(storage_key, secret, user_id||key_id||"imported key")` and sends the resulting ciphertext to the key server over the secure channel.
-    1. [Stores](#store-a-secret-locally) the ciphertext and associated data locally.
+    1. [Stores](#store-a-secret-locally) the ciphertext and associated data `user_id||key_id||"imported key"` locally.
 1. The key server:
     1. Runs a validity check on the received ciphertext (i.e., the ciphertext must be of the expected format and length).
-    1. [Stores](#server-side-storage) a tuple containing the received ciphertext, `user_id`, `key_id`, and the additional context `"imported key"` in the server database.
+    1. [Stores](#server-side-storage) a tuple containing the received ciphertext, and the associated data `user_id||key_id||"imported key"`in the server database.
     1. Sends an ACK to the client.
 1. The client:
     1. Closes the session.

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -76,8 +76,8 @@ Protocol:
 1. The client:
    1. [Opens a request session](systems-architecture.md#request-session) for the given user id `user_id`. 
    1. Calls [`retrieve_storage_key`](#retrievestoragekey-functionality), the output of which is `storage_key`. The implementation SHOULD keep this key in memory only and not write to disk.
-   1. [Retrieves](#client-side-storage) the ciphertext `ciphertext` associated to `key_id` from local storage. 
-        1. If successful, computes `arbitrary_key = Dec(storage_key, ciphertext, user_id||key_id)`, outputs `arbitrary_key`, and closes the request session. 
+   1. [Retrieves](#client-side-storage) the ciphertext `ciphertext` associated to `key_id` and the associated data `associated_data` from local storage. 
+        1. If successful, computes `arbitrary_key = Dec(storage_key, ciphertext, associated_data)`, outputs `arbitrary_key`, and closes the request session. 
         1. Otherwise, continues.
    1. Sends a request message to the key server over the open session's secure channel. This message MUST indicate the desire to retrieve the backed up secret and contain `user_id` and `key_id`.
 1. The key server:

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -43,11 +43,8 @@ Protocol:
    1. Sends a request message to the key server over the session's secure channel. This message MUST indicate the desire to store a secret remotely and contain `user_id`.
 1. The key server:
    1. Runs a validity check on the received request and `user_id`(i.e., there must be a valid open request session, the request must conform to the expected format, and `user_id` must be of the expected format and length, and should match that of the open request session). If this check fails, the server MUST reject the request.
-   1. Generates `key_id`, a globally unique identifier as follows:
-        1. Generates `randomness` as 32 bytes of randomness output from `rng`.
-        1. Computes `key_id` as `Hash(domain_sep, 16, user_id, 32, randomness)`, truncated to 128-bits if necessary, where `domain_sep` is a static string acting as a domain separator, prepended with its length in bytes.
-        1. This functionality should fail (with negligible probability) if the generated identifier is not unique among the key server's stored identifiers. 
-        1. Sends `key_id` to the client over the secure channel.
+   1. Runs the [Generate a key identifier](#generate-a-key-identifier) subprotocol, the output of which is a globally unique identifier `key_id`.
+   1. Sends `key_id` to the client over the secure channel.
 1. The client:
     1. Runs the [generate](#generate-a-secret) protocol on input `(32, rng, user_id||key_id)` to get a secret `arbitrary_key`.
     1. Computes `Enc(storage_key, arbitrary_key, user_id||key_id)` and sends the resulting ciphertext to the key server over the secure channel.
@@ -131,11 +128,8 @@ Protocol:
    1. Sends a request message to the key server over the session's secure channel. This message MUST indicate the desire to store an imported secret remotely and contain `user_id`.
 1. The key server:
    1. Runs a validity check on the received request and `user_id`(i.e., there must be a valid open request session, the request must conform to the expected format, and `user_id` must be of the expected format and length, and should match that of the open request session). If this check fails, the server MUST reject the request.
-   1. Generates `key_id`, a globally unique identifier as follows:
-        1. Generates `randomness` as 32 bytes of randomness output from `rng`.
-        1. Computes `key_id` as `Hash(domain_sep, 16, user_id, 32, randomness)`, truncated to 128-bits if necessary, where `domain_sep` is a static string acting as a domain separator, prepended with its length in bytes.
-        1. This functionality should fail (with negligible probability) if the generated identifier is not unique among the key server's stored identifiers. 
-        1. Sends `key_id` to the client over the secure channel.
+   1. Runs the [Generate a key identifier](#generate-a-key-identifier) subprotocol, the output of which is a globally unique identifier `key_id`. 
+   1. Sends `key_id` to the client over the secure channel.
 1. The client:
     1. Computes the secret `imported_key` as .
     1. Computes `Enc(storage_key, imported_key, user_id||key_id||"imported key")` and sends the resulting ciphertext to the key server over the secure channel.
@@ -165,7 +159,7 @@ See [the current development phase](current-development-phase.md#cryptographic-p
 Inter-dependency constraints include:
 - The length of the a key for `Enc` must be no more than 255 times the length of the output of `Hash`.
 
-### Generate a secret
+#### Generate a secret
 Input:
   - A length `len` in bytes. Default length is 32 bytes.
   - A seeded CSPRNG `rng`.
@@ -183,6 +177,14 @@ Protocol:
 
 Usage guidance:
 Code that consumes an `arbitrary_key` SHOULD include validation checks specific to the context before use, i.e., an `arbitrary_key` SHOULD be used only in the context for which it was initially generated.
+
+#### Generate a key identifier
+This subprotocol is run by the key server to generate a 32-byte globally unique identifier, `key_id`, as follows:
+1. Generates `randomness` as 32 bytes of randomness output from `rng`.
+1. Computes `key_id` as `Hash(domain_sep, 16, user_id, 32, randomness)`, truncated to 128-bits if necessary, where `domain_sep` is a static string acting as a domain separator, prepended with its length in bytes.
+
+This functionality should fail (with negligible probability) if the generated identifier is not unique among the key server's stored identifiers. 
+
 
 #### `retrieve_storage_key` functionality
 This functionality allows the client to request and receive the key `storage_key` from the key server, where `storage_key` is a symmetric key for the implementation's selected AEAD used for remote storage.

--- a/current-development-phase.md
+++ b/current-development-phase.md
@@ -47,7 +47,7 @@ See the [Operations on Arbitrary Secrets page](cryptographic_flows.md#) for deta
     1. Any communication with the key server that occurs in serving an import request MUST occur via a mutually authenticated channel that satisfies confidentiality and integrity.
 1. The asset owner may _export_ the secret from the system. The export format for the key SHOULD allow for easy transfer of the key material to another digital asset management system, i.e., secrets should be portable.
     1. The default expected format is as bytes of the form ``len || secret``, where `len` is 1 byte that represents the length of the secret `secret` in bytes.
-    1. The implementation may define other acceptable import formats.
+    1. The implementation may define other acceptable export formats.
     1. Any communication with the key server that occurs in serving an export request MUST occur via a mutually authenticated channel that satisfies confidentiality and integrity. 
 1. The asset owner may _audit_ the operations performed by the key server on a given secret. This allows the asset owner to retrieve a log of operations from the key server.
     1. Audit log retrieval MUST occur via a mutually authenticated channel that satisfies confidentiality and integrity.

--- a/current-development-phase.md
+++ b/current-development-phase.md
@@ -44,7 +44,6 @@ See the [Operations on Arbitrary Secrets page](cryptographic_flows.md#) for deta
 1. The asset owner may _import_ a secret to the system in an appropriate format. 
     1. The default expected format is as bytes of the form ``len || secret``, where `len` is 1 byte that represents the length of the secret `secret` in bytes.
     1. The implementation may define other acceptable import formats.
-    1. The user may choose to store the imported secret locally or on the key server.
     1. Any communication with the key server that occurs in serving an import request MUST occur via a mutually authenticated channel that satisfies confidentiality and integrity.
 1. The asset owner may _export_ the secret from the system. The export format for the key SHOULD allow for easy transfer of the key material to another digital asset management system, i.e., secrets should be portable.
     1. The default expected format is as bytes of the form ``len || secret``, where `len` is 1 byte that represents the length of the secret `secret` in bytes.


### PR DESCRIPTION
Closes #33.
Closes #34.

This PR required some modifications to the existing protocols:
- Generate and Store: Some clarification as to the role of the calling application (versus `local-client` was added. This amounts to clarifying that the last action of the client is to output the key identifier to the calling application.
- Retrieve: This functionality now takes context as to the intended use of the retrieved secret, in order to support local use as well as export. I also included a `NULL` context, which retrieves the secret but doesn't do anything useful with it. I did this mainly with testing and extensibility in mind (e.g., we may have some local operations possible when we add signing keys to the system).