### PR TITLE
Add definition for "Operation"

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -24,12 +24,10 @@
 
 **Message**: A collection of data required to advance a protocol by one step. Messages are sent across channels between a client and server.
 
-**Protocol**: A multi-message process that accomplishes a particular task within a workflow. *Example: Generate a secret*
+**Operation**: Any action undertaken by the client that involves communication with the key server, e.g., register, generate and store a secret, retrieve a secret.
 
-**Request**: Any operation undertaken by the client that involves communication with the key server, e.g., register, generate and store a secret, retrieve a secret.
+**Protocol**: A multi-message process that accomplishes a particular task within a workflow. *Example: Generate a secret*
 
 **Service provider**: The entity using Lock Keeper to build a full-featured digital asset manager.
 
 **Session**: A logical interaction between a client and one or more servers at the application layer. Sessions use one or more channels to communicate with messages in order to execute protocols.
-
-**Workflow/Flow**: A set of steps that accomplish an action on behalf of a user. Completing a workflow requires the execution of one or more protocols. *Example: Generate and store a secret*


### PR DESCRIPTION
I found myself using the word "Operation" a lot when writing the client epic. We were trying to think of a better word for "
"Workflow" and I think this is a good replacement.

I repurposed the definition for "Request" because I think it fits the most closely and removed the "Workflow/Flow" definition. I think "Request" already has a well-established networking definition and might cause confusion down the line.

"Operation" is a pretty common word as well, but it seems to always be context dependent in my experience.