### PR TITLE
Process Feedback Nits

### DIFF
--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -156,8 +156,7 @@ Protocol:
         1. The `user_id` must be of the expected format and length, and should match that of the open request session,
         1. The `key_id` must be associated with the given `user_id` in the key server's database.
         1. The intended use must match one of the expected options.
-    1. [Retrieves](#server-side-storage) the associated ciphertext, `ciphertext` and associated data, `associated_data`, for the given pair `(user_id, key_id)` from its database and sends this ciphertext, together with the associated data, to the client.
-        - [TODO #36](https://github.com/boltlabs-inc/key-mgmt-spec/issues/36): The key server should log the intended use of this retrieval request.
+    1. [Retrieves](#server-side-storage) the associated ciphertext, `ciphertext` and associated data, `associated_data`, for the given pair `(user_id, key_id)` from its database and sends `ciphertext` and `associated data` to the client.
     1. Stores the current request information, including the outcome of the validity check, in an [audit log](#audit-logs) associated with the given user.  
     1. Outputs a success indicator.
 1. The client:
@@ -289,7 +288,7 @@ Protocol:
     1. Sends a request message to the key server over the open session's secure channel. This message MUST indicate the desire to retrieve the storage key and contain `user_id`.
 1. The key server:
     1. Runs a validity check on the received request and `user_id` (i.e., there must be a valid open request session, the request must conform to the expected format and content, and `user_id` must be of the expected format and length, and should match that of the open request session). If this check fails, the server MUST reject the request.
-    1. [Retrieves](#server-side-storage) the associated storage key ciphertext for the given user from its database and sends the ciphertext to the client.
+    1. [Retrieves](#server-side-storage) the associated storage key ciphertext, `ciphertext` for the given user from its database and sends `ciphertext` to the client.
     1. Outputs a success indicator.
 1. The client:
     1. Derives `master_key`, a symmetric key of length `len` bytes for [`Enc`](#external-dependencies), from `export_key`, as follows:

--- a/cryptographic_flows.md
+++ b/cryptographic_flows.md
@@ -98,7 +98,7 @@ Output:
 Protocol:
 1. The client:
    1. [Opens a request session](systems-architecture.md#request-session) for the given credentials `user_credentials`. The client receives as output an open secure channel and a user identifier `user_id`.
-   1. Calls [`retrieve_storage_key`](#retrievestoragekey-functionality), the output of which is `storage_key`.
+   1. Calls [`retrieve_storage_key`](#retrieve_storage_key-protocol), the output of which is `storage_key`.
    1. Sends a request message to the key server over the session's secure channel. This message MUST indicate the desire to store a secret remotely and contain `user_id`.
 1. The key server:
    1. Runs a validity check on the received request and `user_id`(i.e., there must be a valid open request session, the request must conform to the expected format, and `user_id` must be of the expected format and length, and should match that of the open request session). If this check fails, the server MUST reject the request.
@@ -143,7 +143,7 @@ Output:
 Protocol:
 1. The client:
    1. [Opens a request session](systems-architecture.md#request-session) for the given credentials `user_credentials`. The client receives as output an open secure channel and a user identifier `user_id`.
-   1. Calls [`retrieve_storage_key`](#retrievestoragekey-functionality), the output of which is `storage_key`. The implementation SHOULD keep this key in memory only and not write to disk.
+   1. Calls [`retrieve_storage_key`](#retrieve_storage_key-protocol), the output of which is `storage_key`. The implementation SHOULD keep this key in memory only and not write to disk.
    1. [Retrieves](#client-side-storage) the ciphertext `ciphertext` associated to `key_id` and the associated data `associated_data` from local storage. 
         1. If successful, computes `arbitrary_key = Dec(storage_key, ciphertext, associated_data)`, outputs `arbitrary_key`, and closes the request session. 
         1. Otherwise, continues.
@@ -200,7 +200,7 @@ Output:
 Protocol:
 1. The client:
    1. [Opens a request session](systems-architecture.md#request-session) for the given credentials `user_credentials`. The client receives as output an open secure channel and a user identifier `user_id`.
-   1. Calls [`retrieve_storage_key`](#retrievestoragekey-functionality), the output of which is `storage_key`.
+   1. Calls [`retrieve_storage_key`](#retrieve_storage_key-protocol), the output of which is `storage_key`.
    1. Sends a request message to the key server over the session's secure channel. This message MUST indicate the desire to store an imported secret remotely and contain `user_id`.
 1. The key server:
    1. Runs a validity check on the received request and `user_id` (i.e., there must be a valid open request session, the request must conform to the expected format, and `user_id` must be of the expected format and length, and should match that of the open request session). If this check fails, the server MUST reject the request.
@@ -298,7 +298,7 @@ Protocol:
     1. Deletes `master_key` from memory.
     1. Outputs `storage_key`.
 
-Usage guidance: Code that calls the `retrieve_storage_key` functionality SHOULD NOT write the output `storage_key` to disk and should make a best effort to drop this key from temporary memory after use of this key is completed.
+Usage guidance: Code that calls the `retrieve_storage_key` protocol SHOULD NOT write the output `storage_key` to disk and should make a best effort to drop this key from temporary memory after use of this key is completed.
 
 #### Client-side storage
 

--- a/current-development-phase.md
+++ b/current-development-phase.md
@@ -62,7 +62,6 @@ We have the following dependencies:
     - This implementation relies on [voprf](https://github.com/novifinancial/voprf), which is tracking [the IETF RFC on OPRFs](https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/).
     - As both of the above RFCs are in flux, we expect ongoing updates.
     - Following the terminology of the RFC, we use the following OPAQUE-3DH configuration: OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, ristretto255, with Argon2 as the KSF, and no shared context information. 
-
 - TLS 1.3. 
     - [TODO #22](https://github.com/boltlabs-inc/key-mgmt-spec/issues/22): Select and add config, setup, and implementation dependency information.
 - Cryptographic Hash Function `Hash`. We use [SHA3-256](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf) throughout in our constructions, as implemented in [sha3](https://docs.rs/sha3/latest/sha3/) by RustCrypto.
@@ -71,8 +70,8 @@ We have the following dependencies:
     - This scheme uses a 256-bit pseudorandom key. There are no further requirements on the format or properties of the key.
     - This implementation will not execute in constant time on processors with a variable-time multiplication operation.
  - HMAC-based key derivation function. We use [hkdf](https://docs.rs/rust-crypto/0.2.36/crypto/hkdf/) by RustCrypto, which implements [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869).
-- [A message authentication code (MAC)].
-    - [TODO #149]([TODO #149](https://github.com/boltlabs-inc/key-mgmt/issues/149): Propagate implementation decisions from #149 here.
+- A message authentication code (MAC).
+    - [TODO #149](https://github.com/boltlabs-inc/key-mgmt/issues/149): Propagate implementation decisions from #149 here.
 
 
 ## Expected Outcomes

--- a/systems-architecture.md
+++ b/systems-architecture.md
@@ -49,7 +49,7 @@ The registration stage of OPAQUE satisfies the following:
     - `account_name`, bytes that represent the asset owner's human-memorable account information, e.g., email address; and
     - `password`, bytes that represent the asset owner's human-memorable secret authentication information.
 1. The key server MUST check that the given user identifier `account_name` is _fresh_ (i.e., no user has previously registered with the given identifier) and of the expected format and length. If this check fails, the key server MUST fail the registration request.
-1. The client receives as output a value `export_key`, which is a pseudorandom value, independent of all other OPAQUE protocol values, that is known only to the client.
+1. The client receives as output a value `export_key`, which is a pseudorandom value, distributed independently of all other OPAQUE protocol values, that is known only to the client.
 1. The key server receives as output a record that corresponds to the client's registration, which includes an identifier `account_name` that matches that of the client.
 
 ##### Authentication stage
@@ -98,7 +98,7 @@ We have the following requirements for using an open registration session:
 1. The key server and the client MUST additionally reject all messages sent over this channel that fail the MAC verification checks.
 1. The only valid request for a registration session is a request to [complete registration](cryptographic_flows.md#complete-registration).
 1. The key server MUST close the session after completion of the complete registration request.
-    - [TODO #51](https://github.com/boltlabs-inc/key-mgmt-spec/issues/51): Set recommendations for sane request limits and timeouts.
+    - [TODO #51](https://github.com/boltlabs-inc/key-mgmt-spec/issues/51): Set recommendations for request limits and timeouts that allow more than one request per session.
 
 ### Opening and using a request session
 The client initiates a request session as a prerequisite for processing any _requests_, i.e., operations that involve communication with the key server.
@@ -125,4 +125,4 @@ We have the following requirements for using an open request session:
 1. The key server and the client MUST additionally reject all messages sent over this channel that fail the MAC verification checks.
 1. The client may then send a single request (i.e., one of store, retrieve, audit, import, export) to the key server during this session.
 1. The key server MUST close the session upon completion of the given request.
-    - [TODO #51](https://github.com/boltlabs-inc/key-mgmt-spec/issues/51): Set recommendations for sane request limits and timeouts.
+    - [TODO #51](https://github.com/boltlabs-inc/key-mgmt-spec/issues/51): Set recommendations for request limits and timeouts that allow more than one request per session.


### PR DESCRIPTION
- Minor fixes and non-normative/usage notes.
- Clarifications to protocol specifications with respect to inputs/outputs by client and server. This includes adding explicit success indicators as outputs for the server throughout.

Closes #98.