### PR TITLE
Import and Create Sigs

### DIFF
--- a/arbitrary-secrets-overview.md
+++ b/arbitrary-secrets-overview.md
@@ -68,22 +68,4 @@ See the [Operations on Arbitrary Secrets page](cryptographic_flows.md#) for deta
     1. Audit logs should be portable, i.e., easily exportable from the system.
     1. Non-normative note: Given the above properties, we do not achieve integrity of the audit logs in the presence of a cheating key server. Future work may address this concern.
 
-## Cryptographic Protocol and Implementation Dependencies
-- [TODO #49](https://github.com/boltlabs-inc/key-mgmt-spec/issues/49): Add dependency information for the above.
-
-We have the following dependencies:
-- We instantiate the asymmetric password-based authenticated key exchange protocol with OPAQUE. We are using [opaque-ke](https://docs.rs/opaque-ke/2.0.0-pre.3/opaque_ke/index.html), which currently implements [version 09 of the IETF RFC](https://datatracker.ietf.org/doc/draft-irtf-cfrg-opaque/09/). This library is under active development, as is the IETF draft. An earlier release of this repository has been audited by NCC Group in June 2021. 
-    - This implementation relies on [voprf](https://github.com/novifinancial/voprf), which is tracking [the IETF RFC on OPRFs](https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/).
-    - As both of the above RFCs are in flux, we expect ongoing updates.
-    - Following the terminology of the RFC, we use the following OPAQUE-3DH configuration: OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, ristretto255, with Argon2 as the KSF, and no shared context information. 
-- TLS 1.3. 
-    - [TODO #22](https://github.com/boltlabs-inc/key-mgmt-spec/issues/22): Select and add config, setup, and implementation dependency information.
-- Cryptographic Hash Function `Hash`. We use [SHA3-256](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf) throughout in our constructions, as implemented in [sha3](https://docs.rs/sha3/latest/sha3/) by RustCrypto.
-- CSPRNG, `rng`.
-- Symmetric AEAD scheme. We are using [chacha20poly1305](https://docs.rs/chacha20poly1305/0.10.1/chacha20poly1305/index.html) by RustCrypto, which implements [RFC 8439](https://tools.ietf.org/html/rfc8439). This library is under active development. An earlier release of this repository was audited by NCC Group in February 2020.
-    - This scheme uses a 256-bit pseudorandom key. There are no further requirements on the format or properties of the key.
-    - This implementation will not execute in constant time on processors with a variable-time multiplication operation.
- - HMAC-based key derivation function. We use [hkdf](https://docs.rs/rust-crypto/0.2.36/crypto/hkdf/) by RustCrypto, which implements [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869).
-- A message authentication code (MAC).
-    - [TODO #149](https://github.com/boltlabs-inc/key-mgmt/issues/149): Propagate implementation decisions from #149 here.
 

--- a/dev-notes.md
+++ b/dev-notes.md
@@ -1,13 +1,12 @@
-
-
-## Development Notes
+# Development Notes
 We are iteratively developing a proof of concept in the single-server setting. In the first phase, we focus on basic support for [arbitrary secrets](#arbitrary-secrets). In the second phase, we extend the system to support [signing keys](#signing-keys).
 
 ## Page Contents
 1. [Arbitrary Secrets](#arbitrary-secrets)<br>
 1. [Signing Keys](#signing-keys) <br>
+1. [Cryptographic Protocol and Implementation Dependencies](#cryptographic-protocol-and-implementation-dependencies)<br>
 
-### Arbitrary Secrets 
+## Arbitrary Secrets 
 We want to build a general-purpose, human-centric system that stores and retrieves secrets on a single server. The resulting proof of concept (PoC) will include basic cryptography to realize an end-to-end encrypted storage of arbitrary secrets. This constitutes a fundamental building block of our larger imagined digital asset management system. 
 
 Basic support for arbitrary secrets includes:
@@ -24,7 +23,7 @@ Extended support for arbitrary secrets includes:
 
 For more details on the above, see [Arbitrary Secrets Overview](arbitrary-secrets-overview.md).
 
-### Signing Keys
+## Signing Keys
 
 We want our system to include support of signing keys. In this phase, we will include support for basic ECDSA signing key generation and use.
 
@@ -32,4 +31,25 @@ As part of this phase, we will extend our existing system functionalities to inc
 - Remote generation and storage of secrets, without local storage.
 - Generic support for generation and use of signing keys. Uses will include retrieval, import/export, generating signatures, and obtaining audit logs.
 
+## Cryptographic Protocol and Implementation Dependencies
+We have the following dependencies:
+- We instantiate the asymmetric password-based authenticated key exchange protocol with OPAQUE. We are using [opaque-ke](https://docs.rs/opaque-ke/2.0.0-pre.3/opaque_ke/index.html), which currently implements [version 09 of the IETF RFC](https://datatracker.ietf.org/doc/draft-irtf-cfrg-opaque/09/). This library is under active development, as is the IETF draft. An earlier release of this repository has been audited by NCC Group in June 2021. 
+    - This implementation relies on [voprf](https://github.com/novifinancial/voprf), which is tracking [the IETF RFC on OPRFs](https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/).
+    - As both of the above RFCs are in flux, we expect ongoing updates.
+    - Following the terminology of the RFC, we use the following OPAQUE-3DH configuration: OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, ristretto255, with Argon2 as the KSF, and no shared context information. 
+- TLS 1.3. 
+    - [TODO #22](https://github.com/boltlabs-inc/key-mgmt-spec/issues/22): Select and add config, setup, and implementation dependency information.
+- Cryptographic Hash Function `Hash`. We use [SHA3-256](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf) throughout in our constructions, as implemented in [sha3](https://docs.rs/sha3/latest/sha3/) by RustCrypto.
+- CSPRNG, `rng`.
+    - [TODO #49](https://github.com/boltlabs-inc/key-mgmt-spec/issues/49): Add dependency information for the above.
+- Symmetric AEAD scheme. We are using [chacha20poly1305](https://docs.rs/chacha20poly1305/0.10.1/chacha20poly1305/index.html) by RustCrypto, which implements [RFC 8439](https://tools.ietf.org/html/rfc8439). This library is under active development. An earlier release of this repository was audited by NCC Group in February 2020.
+    - This scheme uses a 256-bit pseudorandom key. There are no further requirements on the format or properties of the key.
+    - This implementation will not execute in constant time on processors with a variable-time multiplication operation.
+ - HMAC-based key derivation function. We use [hkdf](https://docs.rs/rust-crypto/0.2.36/crypto/hkdf/) by RustCrypto, which implements [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869).
+- A message authentication code (MAC).
+    - [TODO #149](https://github.com/boltlabs-inc/key-mgmt/issues/149), [TODO #49](https://github.com/boltlabs-inc/key-mgmt-spec/issues/49): Propagate implementation decisions from #149 here.
+- Cryptographic signing primitives:
+    - ECDSA on secp256
+    - Ed25519 (i.e., EdDSA on edwards25519).
+    - [TODO #49](https://github.com/boltlabs-inc/key-mgmt-spec/issues/49): Propagate implementation decisions here.
 

--- a/system-functionalities.md
+++ b/system-functionalities.md
@@ -9,6 +9,8 @@ This page contains protocol descriptions for Lock Keeper system functionalities.
     1. [Retrieve a Secret](#retrieve-a-secret) <br>
     1. [Import a Secret](#import-a-secret) <br>
 1. [Operations on Signing Keys](#operations-on-signing-keys) <br>
+    1. [Inherited Operations](#inherited-operations) <br>
+    1. [Sign a Message](#sign-a-message) <br>
 1. [Cryptographic and Supporting Dependencies](#cryptographic-and-supporting-operations) <br>
     1. [External Dependencies](#external-dependencies) <br>
     1. [Generate a Secret Helper](#generate-a-secret) <br>
@@ -328,7 +330,9 @@ Implementation guidance: For security, all verification checks run by the key se
 
 
 ## Operations on Signing Keys
+The asset owner can create and use signing keys in a manner similar to arbitrary secrets, with the additional operation of creating signatures.
 
+### Inherited Operations
 All of the [protocols for arbitrary secrets](#operations-on-arbitrary-secrets) should be supported. The only difference is the type of key created and used. That is, calling the generation functionality should allow the asset owner to create one of the following key types:
 - ECDSA on secp256 curve; or
 - Ed25519 (i.e., EdDSA on edwards25519).
@@ -384,14 +388,14 @@ Implementation guidance: For security, all verification checks run by the key se
 
 ## Cryptographic and Supporting Operations
 #### External dependencies
-See [the current development phase](current-development-phase.md#cryptographic-protocol-and-implementation-dependencies) for our selections. Dependencies include:
+See [development notes](dev-notes.md#cryptographic-protocol-and-implementation-dependencies) for our selections. Dependencies include:
 
 - Cryptographic Hash Function `Hash`. 
 - CSPRNG, `rng`.
 - A symmetric AEAD scheme that consists of:
     - An encryption function `Enc` that takes a pair `(key, msg, data)`, where `key` is the symmetric key, `msg` is the message to be encrypted, and `data` is OPTIONAL associated data, and outputs a ciphertext.
     - A decryption function `Dec` that takes a pair `(key, ciphertext, data)`, where `key` is the symmetric key,`ciphertext` is the a ciphertext to be decrypted, and `data` is OPTIONAL associated data, and outputs a plaintext.
-- [A key derivation function (KDF)] that takes a tuple `(input_key, context, len)`, where `input_key` is the input key material, `context` is an optional context and application-specific information, and `len` is the length of the output keying material in bytes.
+- A key derivation function (KDF) that takes a tuple `(input_key, context, len)`, where `input_key` is the input key material, `context` is an optional context and application-specific information, and `len` is the length of the output keying material in bytes.
 - Cryptographic signing primitives:
     - ECDSA on secp256
     - Ed25519 (i.e., EdDSA on edwards25519).

--- a/system-functionalities.md
+++ b/system-functionalities.md
@@ -99,8 +99,8 @@ This client-initiated functionality allows for two ways of generating and storin
 - local generation with remote backup; and
 - remote-only generation and storage.
 
-#### Local secret generation with remote backup
-This client-initiated functionality generates a secret locally and stores the result both locally and remotely.
+#### Local secret generation with remote encrypted backup
+This client-initiated functionality generates a secret locally and stores the result both locally and remotely. The key server does NOT get access to the secret material generated during this protocol.
 
 Input:
 - Client input:
@@ -139,7 +139,7 @@ Protocol:
     1. Outputs `key_id` to the calling application.
 
 #### Remote-only secret generation and storage
-This client-initiated functionality sends a request to the key server to generate and store a secret remotely.
+This client-initiated functionality sends a request to the key server to generate and store a secret remotely. The key server DOES have access to the secret material generated during this protocol.
 
 Input:
 - Client input:
@@ -314,7 +314,7 @@ Protocol:
 
 All of the [protocols for arbitrary secrets](#operations-on-arbitrary-secrets) should be supported. The only difference is the type of key created and used. That is, calling the generation functionality should allow the asset owner to create one of the following key types:
 - ECDSA on secp256 curve; or
-- EdDSA on ed25519.
+- Ed25519 (i.e., EdDSA on edwards25519).
 
 Signing keys have an additional supported operation, namely, the creation of a signature.
 
@@ -352,7 +352,7 @@ Protocol:
             - `message` should have the expected domain and format for the signing key type,
             - `user_id` must be of the expected format and length, and should match that of the open request session in which the request was sent. 
         - The `key_id` must be a key created for the user with the given `user_id`.
-    1. Computes `signature`, the signature on `message` and sends `signature` to the client.
+    1. Computes `signature`, the signature on `message`, and sends `signature` to the client.
     1. Stores the current request information, including the outcome of the validity check, in an [audit log](#audit-logs) associated with the given user.    
     1. Outputs a success indicator.
 1. The client:
@@ -369,8 +369,10 @@ See [the current development phase](current-development-phase.md#cryptographic-p
     - An encryption function `Enc` that takes a pair `(key, msg, data)`, where `key` is the symmetric key, `msg` is the message to be encrypted, and `data` is OPTIONAL associated data, and outputs a ciphertext.
     - A decryption function `Dec` that takes a pair `(key, ciphertext, data)`, where `key` is the symmetric key,`ciphertext` is the a ciphertext to be decrypted, and `data` is OPTIONAL associated data, and outputs a plaintext.
 - [A key derivation function (KDF)] that takes a tuple `(input_key, context, len)`, where `input_key` is the input key material, `context` is an optional context and application-specific information, and `len` is the length of the output keying material in bytes.
+- Cryptographic signing primitives:
+    - ECDSA on secp256
+    - Ed25519 (i.e., EdDSA on edwards25519).
    
-
 Inter-dependency constraints include:
 - The length of the a key for `Enc` must be no more than 255 times the length of the output of `Hash`.
 

--- a/system-functionalities.md
+++ b/system-functionalities.md
@@ -266,7 +266,7 @@ Protocol:
    1. Sends `key_id` to the client over the secure channel.
 1. The client:
     1. Computes `Enc(storage_key, secret, user_id||key_id||"imported key")` and sends the resulting ciphertext to the key server over the secure channel.
-    1. [Stores](#client-side-storage) the ciphertext and associated data `user_id||key_id||"imported key"` locally.
+    1. [Stores](#client-side-storage) `secret` and associated data `user_id||key_id||"imported key"` locally.
 1. The key server:
     1. Runs a validity check on the received ciphertext (i.e., the ciphertext must be of the expected format and length).
     1. [Stores](#server-side-storage) a tuple containing the received ciphertext, and the associated data `user_id||key_id||"imported key"`in the server database.
@@ -341,7 +341,7 @@ Output:
 - Client output:
     - A signature.
 - Server output:
-    - A success indicator
+    - A success indicator.
 
 Protocol:
 1. The client:

--- a/system-functionalities.md
+++ b/system-functionalities.md
@@ -126,11 +126,11 @@ Protocol:
    1. Sends `key_id` to the client over the secure channel.
 1. The client:
     1. Runs the [generate](#generate-a-secret) protocol on input `(32, rng, user_id||key_id)` to get a secret `arbitrary_key`.
-    1. Computes `Enc(storage_key, arbitrary_key, user_id||key_id)` and sends the resulting ciphertext to the key server over the secure channel.
-    1. [Stores](#client-side-storage) the ciphertext and associated data `user_id||key_id` locally.
+    1. Computes `ciphertext = Enc(storage_key, arbitrary_key, user_id||key_id)` and sends `ciphertext` to the key server over the secure channel.
+    1. [Stores](#client-side-storage) `arbitrary_key`and associated data `user_id||key_id` locally.
 1. The key server:
-    1. Runs a validity check on the received ciphertext (i.e., the ciphertext must be of the expected format and length).
-    1. [Stores](#server-side-storage) a tuple containing the received ciphertext, `user_id`, and `key_id` in the server database.
+    1. Runs a validity check on , `ciphertext` (i.e., the ciphertext must be of the expected format and length).
+    1. [Stores](#server-side-storage) a tuple containing `ciphertext`, `user_id`, and `key_id` in the server database.
     1. Stores the current request information, including the outcome of the validity check, in an [audit log](#audit-logs) associated with the given user.    
     1. Sends an ACK to the client.
     1. Outputs a success indicator.
@@ -440,15 +440,16 @@ Usage guidance: Code that calls the `retrieve_storage_key` protocol SHOULD NOT w
 
 #### Client-side storage
 
-For now, simple clear-text storage is acceptable.
-- [TODO #39](https://github.com/boltlabs-inc/key-mgmt-spec/issues/39): Include appropriate requirements for client-side secure storage and generate relevant issues in key-mgmt.
+For now, in the PoC setting, simple clear-text storage is acceptable. 
+- [TODO #39](https://github.com/boltlabs-inc/key-mgmt-spec/issues/39): Include appropriate requirements for client-side secure storage and generate relevant issues in key-mgmt:
+    -  The client library MUST encrypt all data stored locally under a key that the user can access without contacting the key server. 
 
 #### Server-side storage
 - [TODO #28](https://github.com/boltlabs-inc/key-mgmt-spec/issues/28). Include appropriate requirements for server-side secure storage and generate relevant issues in key-mgmt.
-- All data stored by the server MUST be encrypted by a key known only to the server.
-- System requirements may change to include the usage of secure enclaves, in which case, the encryption key MUST be known only to the enclave.
+    - All data stored by the server MUST be encrypted by a key known only to the server.
+    - System requirements may change to include the usage of secure enclaves, in which case, the encryption key MUST be known only to the enclave.
 
-##### Audit Logs
+#### Audit Logs
 The server storage should include a per-user audit log that tracks system registration and logins, key use requests, and audit log requests. A single log entry contains the following information about each action: action, actor, date, outcome (e.g. success or failure), any related key identifier.
 
 

--- a/system-functionalities.md
+++ b/system-functionalities.md
@@ -323,6 +323,7 @@ Implementation guidance: We pick these ECDSA/EdDSA parameters in order to provid
 ### Sign a Message
 #### Local signing
 If the signing key is stored locally, the client retrieves and signs the message client-side.
+    - [TODO #116](https://github.com/boltlabs-inc/key-mgmt-spec/issues/116).
 
 #### Remote signing
 This client-initiated functionality sends a request to the key server to generate and store a secret remotely.

--- a/systems-architecture.md
+++ b/systems-architecture.md
@@ -29,6 +29,8 @@ We wish to ensure the following in our implementation:
     1. A _request session_: This type of session is opened when an asset owner who has previously registered with the system sends a request for the key sever to perform an operation on a secret (i.e., store, retrieve, audit, import, export).
         1. Request sessions MUST provide mutual entity authentication.
         1. Request sessions MUST provide confidentiality and integrity.
+1. For security, all verification checks run by the key server during session setup and resumption MUST run in constant-time.
+
 
 ### Underlying transport layer
 We assume a Public Key Infrastructure (PKI). For all session types, the local client first authenticates the key server and opens a channel using TLS 1.3.
@@ -91,6 +93,8 @@ Protocol:
 1. The key server sends `user_id` to the client over the authenticated channel.
 1. At this point, the registration session is considered _open_. 
 
+Implementation guidance: For security, all verification checks run by the key server MUST run in constant-time.
+
 #### Using a registration session
 We have the following requirements for using an open registration session:
     
@@ -99,6 +103,8 @@ We have the following requirements for using an open registration session:
 1. The only valid request for a registration session is a request to [complete registration](cryptographic_flows.md#complete-registration).
 1. The key server MUST close the session after completion of the complete registration request.
     - [TODO #51](https://github.com/boltlabs-inc/key-mgmt-spec/issues/51): Set recommendations for request limits and timeouts that allow more than one request per session.
+
+Implementation guidance: For security, all verification checks run by the key server MUST run in constant-time.
 
 ### Opening and using a request session
 The client initiates a request session as a prerequisite for processing any _requests_, i.e., operations that involve communication with the key server.
@@ -119,6 +125,9 @@ Protocol:
 1. The key server retrieves the identifier `user_id` associated with the authenticated client and sends `user_id` to the client over the authenticated channel.
 1. At this point, the request session is consider _open_. 
 
+Implementation guidance: For security, all verification checks run by the key server MUST run in constant-time.
+
+
 #### Using a request session
 We have the following requirements for using an open request session:
 1. All messages sent between the client and server MUST be over this authenticated channel, i.e., all messages should include an authentication tag that is computed under the selected MAC scheme using the shared key. 
@@ -126,3 +135,5 @@ We have the following requirements for using an open request session:
 1. The client may then send a single request (i.e., one of store, retrieve, audit, import, export) to the key server during this session.
 1. The key server MUST close the session upon completion of the given request.
     - [TODO #51](https://github.com/boltlabs-inc/key-mgmt-spec/issues/51): Set recommendations for request limits and timeouts that allow more than one request per session.
+
+Implementation guidance: For security, all verification checks run by the key server MUST run in constant-time.


### PR DESCRIPTION
Closes #114: importing a key changes (to allow for remote-only storage).
Closes #109: obtaining a signature from key server (where key server signs)

Makes progress on #107 (but does not complete bc issues haven't yet been created to implement changes made to spec). i.e., protocols for local and remote signing added to spec.

Clarifies some issues around client-side storage (#39) and as a related issue, fixes the "local generation of a secret" workflow to be consistent with the new local signing functionality.

Contains some minor cleanup and additional implementation guidance throughout for consistency and redundancy.